### PR TITLE
[MIS] changed MIS graph argument to &graph

### DIFF
--- a/benchmarks/maximalIndependentSet/bench/MIS.h
+++ b/benchmarks/maximalIndependentSet/bench/MIS.h
@@ -4,5 +4,5 @@ using vertexId = uint;
 using edgeId = uint;
 using Graph = graph<vertexId,edgeId>;
 
-parlay::sequence<char> maximalIndependentSet(Graph G);
+parlay::sequence<char> maximalIndependentSet(Graph const &G);
 

--- a/benchmarks/maximalIndependentSet/incrementalMIS/MIS.C
+++ b/benchmarks/maximalIndependentSet/incrementalMIS/MIS.C
@@ -41,7 +41,7 @@ struct MISstep {
   char flag;
   parlay::sequence<char> &Flags;
   Graph const &G;
-  MISstep(parlay::sequence<char> & F, Graph &G) : Flags(F), G(G) {}
+  MISstep(parlay::sequence<char> & F, const Graph &G) : Flags(F), G(G) {}
 
   bool reserve(size_t i) {
     size_t d = G[i].degree;
@@ -60,7 +60,7 @@ struct MISstep {
   bool commit(size_t i) { return (Flags[i] = flag) > 0;}
 };
 
-parlay::sequence<char> maximalIndependentSet(Graph GS) {
+parlay::sequence<char> maximalIndependentSet(Graph const &GS) {
   size_t n = GS.n;
   parlay::sequence<char> Flags(n, (char) 0);
   MISstep mis(Flags, GS);

--- a/benchmarks/maximalIndependentSet/ndMIS/MIS.C
+++ b/benchmarks/maximalIndependentSet/ndMIS/MIS.C
@@ -36,7 +36,7 @@ using namespace std;
 // and Flags[v] = 2 means vertex is not in MIS
 
 // nondeterministic greed algorithm
-parlay::sequence<char> maximalIndependentSet(Graph G) {
+parlay::sequence<char> maximalIndependentSet(const Graph &G) {
   size_t n = G.n;
   parlay::sequence<char> Flags(n, (char) 0);
   parlay::sequence<bool> V(n, false);

--- a/benchmarks/maximalIndependentSet/serialMIS/MIS.C
+++ b/benchmarks/maximalIndependentSet/serialMIS/MIS.C
@@ -29,7 +29,8 @@
 //    MAXIMAL INDEPENDENT SET
 // **************************************************************
 
-parlay::sequence<char> maximalIndependentSet(Graph G) {
+parlay::sequence<char> maximalIndependentSet(Graph const &G)
+{
   size_t n = G.n;
   parlay::sequence<char> Flags(n, (char) 0);
   for (size_t i = 0; i < n; i++) {


### PR DESCRIPTION
Before, these were the execution times using runall:
```
serialMIS : 1 : geomean of geomeans = 3.269
incrementalMIS : 16 : geomean of geomeans = 0.329
```

After this commit, execution times are decreased and the speedup is increased:
```
serialMIS : 1 : geomean of geomeans = 1.922
incrementalMIS : 16 : geomean of geomeans = 0.151
```