### PR TITLE
[.gitignore] Ignore object files, *Check, and testInputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*testInputs
+*testInputs_small
+*Check
+*.pyc


### PR DESCRIPTION
Since these are auto-generated, they likely need not be committed in the git history