### PR TITLE
Pass text=True to subprocess.Popen.

### DIFF
--- a/benchmarks/ANN/vamana/runTestsANN.py
+++ b/benchmarks/ANN/vamana/runTestsANN.py
@@ -25,7 +25,8 @@ def onPprocessors(command,p) :
   
 def shellGetOutput(str) :
   process = subprocess.Popen(str,shell=True,stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             text=True)
   output, err = process.communicate()
   
   if (len(err) > 0):

--- a/common/runTests.py
+++ b/common/runTests.py
@@ -14,12 +14,13 @@ def onPprocessors(command,p) :
   
 def shellGetOutput(str) :
   process = subprocess.Popen(str,shell=True,stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             text=True)
   output, err = process.communicate()
   
   if (len(err) > 0):
       raise NameError(str+"\n"+output+err)
-  return output.decode("utf-8")
+  return output
 
 def stripFloat(val) :
   trunc = float(int(val*1000))/1000

--- a/common/runTestsANN.py
+++ b/common/runTestsANN.py
@@ -25,7 +25,8 @@ def onPprocessors(command,p) :
   
 def shellGetOutput(str) :
   process = subprocess.Popen(str,shell=True,stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             text=True)
   output, err = process.communicate()
   
   if (len(err) > 0):


### PR DESCRIPTION
This makes Python return stdout/stderr as strings, rather than byte sequences, meaning we can concatenate them with strings afterwards.

Without this change, some error paths crash with a run-time type error under Python 3.

This is really a followup to #11, where I missed some error paths.