### PR TITLE
Fix link flags placement in makefiles

### DIFF
--- a/benchmarks/ANN/bench/Makefile
+++ b/benchmarks/ANN/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/ANN/vamana/Makefile
+++ b/benchmarks/ANN/vamana/Makefile
@@ -6,10 +6,10 @@ BENCH = neighbors
 include common/MakeBench
 
 bvec_to_u8bin : bvec_to_u8bin.cpp
-	$(CC) $(CFLAGS) -o bvec_to_u8bin bvec_to_u8bin.cpp $(LFLAGS) 
+	$(CC) $(CFLAGS) -o bvec_to_u8bin bvec_to_u8bin.cpp $(LFLAGS)
 
 compute_groundtruth : compute_groundtruth.cpp
-	$(CC) $(CFLAGS) -o compute_groundtruth compute_groundtruth.cpp $(LFLAGS) 
+	$(CC) $(CFLAGS) -o compute_groundtruth compute_groundtruth.cpp $(LFLAGS)
 
 crop_sift : crop_sift.cpp
-	$(CC) $(CFLAGS) -o crop_sift crop_sift.cpp $(LFLAGS) 
+	$(CC) $(CFLAGS) -o crop_sift crop_sift.cpp $(LFLAGS)

--- a/benchmarks/BWDecode/bench/Makefile
+++ b/benchmarks/BWDecode/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/breadthFirstSearch/bench/Makefile
+++ b/benchmarks/breadthFirstSearch/bench/Makefile
@@ -3,7 +3,7 @@ BNCHMRK = BFS
 
 CHECKFILES = $(BNCHMRK)Check.o
 
-COMMON = 
+COMMON =
 
 INCLUDE = -Icommon
 
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/classify/bench/Makefile
+++ b/benchmarks/classify/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/comparisonSort/bench/Makefile
+++ b/benchmarks/comparisonSort/bench/Makefile
@@ -1,7 +1,7 @@
 include common/parallelDefs
 
-sortCheck: sortCheck.C 
-	$(CC) $(CFLAGS) $(LFLAGS) -o sortCheck sortCheck.C
+sortCheck: sortCheck.C
+	$(CC) $(CFLAGS) -o sortCheck sortCheck.C $(LFLAGS)
 
 clean :
 	rm -f sortCheck

--- a/benchmarks/concurrentKNN/bench/Makefile
+++ b/benchmarks/concurrentKNN/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/concurrentKNN/octTree/Makefile
+++ b/benchmarks/concurrentKNN/octTree/Makefile
@@ -7,4 +7,4 @@ CFLAGS += -DNoHelp #-DVersioned -DLazyStamp #-DHandOverHand
 include common/MakeBench
 
 lucy_utils: lucy_utils.cpp
-	$(CC) $(CFLAGS) -o lucy_utils lucy_utils.cpp $(LFLAGS) 
+	$(CC) $(CFLAGS) -o lucy_utils lucy_utils.cpp  $(LFLAGS)

--- a/benchmarks/convexHull/bench/Makefile
+++ b/benchmarks/convexHull/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/delaunayRefine/bench/Makefile
+++ b/benchmarks/delaunayRefine/bench/Makefile
@@ -1,7 +1,7 @@
 include common/parallelDefs
 BNCHMRK = refine
 
-CHECKFILES = $(BNCHMRK)Check.o 
+CHECKFILES = $(BNCHMRK)Check.o
 
 COMMON = 
 
@@ -11,7 +11,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/delaunayTriangulation/bench/Makefile
+++ b/benchmarks/delaunayTriangulation/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/histogram/bench/Makefile
+++ b/benchmarks/histogram/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/integerSort/bench/Makefile
+++ b/benchmarks/integerSort/bench/Makefile
@@ -3,7 +3,7 @@ include common/parallelDefs
 INCLUDE = -Icommon
 
 isortCheck: isortCheck.C 
-	$(CC) $(CFLAGS) $(LFLAGS) $(INCLUDE) -o isortCheck isortCheck.C
+	$(CC) $(CFLAGS) $(INCLUDE) -o isortCheck isortCheck.C $(LFLAGS)
 
 clean :
 	rm -f isortCheck

--- a/benchmarks/invertedIndex/bench/Makefile
+++ b/benchmarks/invertedIndex/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/longestRepeatedSubstring/bench/Makefile
+++ b/benchmarks/longestRepeatedSubstring/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/maximalIndependentSet/bench/Makefile
+++ b/benchmarks/maximalIndependentSet/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/maximalMatching/bench/Makefile
+++ b/benchmarks/maximalMatching/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/minSpanningForest/bench/Makefile
+++ b/benchmarks/minSpanningForest/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/nBody/bench/Makefile
+++ b/benchmarks/nBody/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/nearestNeighbors/bench/Makefile
+++ b/benchmarks/nearestNeighbors/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/rangeQuery2d/bench/Makefile
+++ b/benchmarks/rangeQuery2d/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/rangeQueryKDTree/bench/Makefile
+++ b/benchmarks/rangeQueryKDTree/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/rangeSearch/bench/Makefile
+++ b/benchmarks/rangeSearch/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/rangeSearch/vamana/Makefile
+++ b/benchmarks/rangeSearch/vamana/Makefile
@@ -1,9 +1,9 @@
 include common/parallelDefsANN
 
-REQUIRE = ../utils/beamSearch.h 
+REQUIRE = ../utils/beamSearch.h
 BENCH = range
 
 include common/MakeBench
 
 compute_range_groundtruth : compute_range_groundtruth.cpp
-	$(CC) $(CFLAGS) -o compute_range_groundtruth compute_range_groundtruth.cpp $(LFLAGS) 
+	$(CC) $(CFLAGS) -o compute_range_groundtruth compute_range_groundtruth.cpp  $(LFLAGS)

--- a/benchmarks/rayCast/bench/Makefile
+++ b/benchmarks/rayCast/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE = -Icommon
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/removeDuplicates/bench/Makefile
+++ b/benchmarks/removeDuplicates/bench/Makefile
@@ -3,7 +3,7 @@ include common/parallelDefs
 BNCHMRK = dedup
 
 $(BNCHMRK)Check : $(BNCHMRK)Check.C
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $(BNCHMRK)Check.C
+	$(CC) $(CFLAGS) -o $@ $(BNCHMRK)Check.C $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o

--- a/benchmarks/spanningForest/bench/Makefile
+++ b/benchmarks/spanningForest/bench/Makefile
@@ -11,7 +11,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f $(BNCHMRK)Check *.o *.pyc

--- a/benchmarks/suffixArray/bench/Makefile
+++ b/benchmarks/suffixArray/bench/Makefile
@@ -2,8 +2,8 @@ include common/parallelDefs
 
 INCLUDE = -Icommon
 
-SACheck: SACheck.C 
-	$(CC) $(CFLAGS) $(LFLAGS) $(INCLUDE) -o SACheck SACheck.C
+SACheck: SACheck.C
+	$(CC) $(CFLAGS) $(INCLUDE) -o SACheck SACheck.C $(LFLAGS)
 
 SATime.o: SATime.C
 	$(CC) $(CFLAGS) $(INCLUDE) -o SATime.o -c SATime.C

--- a/benchmarks/wordCounts/bench/Makefile
+++ b/benchmarks/wordCounts/bench/Makefile
@@ -12,7 +12,7 @@ INCLUDE =
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 
 $(BNCHMRK)Check : $(CHECKFILES)
-	$(CC) $(LFLAGS) -o $@ $(CHECKFILES)
+	$(CC) -o $@ $(CHECKFILES) $(LFLAGS)
 
 clean :
 	rm -f wcCheck *.o

--- a/testData/geometryData/Makefile
+++ b/testData/geometryData/Makefile
@@ -7,25 +7,25 @@ TO_UPDATE = triangles addRays toNodes
 .PHONY: all clean
 all: $(GENERATORS)
 
-%.o : %.C $(COMMON) 
+%.o : %.C $(COMMON)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-randPoints : randPoints.C geometryData.h $(COMMON) 
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+randPoints : randPoints.C geometryData.h $(COMMON)
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
-toNodes : toNodes.C $(COMMON) 
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+toNodes : toNodes.C $(COMMON)
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
-triangles : triangles.C geometryData.h $(COMMON) 
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+triangles : triangles.C geometryData.h $(COMMON)
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
-addRays : addRays.C $(COMMON) 
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+addRays : addRays.C $(COMMON)
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 clean :
 	rm -f *.o $(GENERATORS)
 	make clean -s -C data
 
-cleansrc : 
+cleansrc :
 	make -s clean
-	rm -f $(COMMON) 
+	rm -f $(COMMON)

--- a/testData/graphData/Makefile
+++ b/testData/graphData/Makefile
@@ -1,7 +1,7 @@
 include common/parallelDefs
 
 COMMON = common/graph.h common/graphIO.h common/graphUtils.h
-GENERATORS = rMatGraph gridGraph randLocalGraph nBy2Comps lineGraph addWeights adjToEdgeArray edgeArrayToAdj 
+GENERATORS = rMatGraph gridGraph randLocalGraph nBy2Comps lineGraph addWeights adjToEdgeArray edgeArrayToAdj
 
 NOTUPDATED_GENERATORS = powerGraph addWeights randDoubleVector fromAdjIdx adjElimSelfEdges starGraph combGraph adjGraphAddWeights binTree randGraph reorderGraph randomizeGraphOrder adjGraphAddSourceSink dimacsToFlowGraph adjToBinary adjWghToBinary
 
@@ -11,80 +11,80 @@ all: $(GENERATORS)
 %.o : %.C $(COMMON)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-rMatGraph : rMatGraph.o 
-	$(CC) $(LFLAGS) -o $@ rMatGraph.o 
+rMatGraph : rMatGraph.o
+	$(CC) -o $@ rMatGraph.o  $(LFLAGS)
 
-gridGraph : gridGraph.o 
-	$(CC) $(LFLAGS) -o $@ gridGraph.o 
+gridGraph : gridGraph.o
+	$(CC) -o $@ gridGraph.o  $(LFLAGS)
 
-nBy2Comps : nBy2Comps.o 
-	$(CC) $(LFLAGS) -o $@ nBy2Comps.o 
+nBy2Comps : nBy2Comps.o
+	$(CC) -o $@ nBy2Comps.o  $(LFLAGS)
 
-lineGraph : lineGraph.o 
-	$(CC) $(LFLAGS) -o $@ lineGraph.o 
+lineGraph : lineGraph.o
+	$(CC) -o $@ lineGraph.o  $(LFLAGS)
 
-powerGraph : powerGraph.o 
-	$(CC) $(LFLAGS) -o $@ powerGraph.o 
+powerGraph : powerGraph.o
+	$(CC) -o $@ powerGraph.o  $(LFLAGS)
 
-randLocalGraph : randLocalGraph.o 
-	$(CC) $(LFLAGS) -o $@ randLocalGraph.o 
+randLocalGraph : randLocalGraph.o
+	$(CC) -o $@ randLocalGraph.o  $(LFLAGS)
 
-randGraph : randGraph.o 
-	$(CC) $(LFLAGS) -o $@ randGraph.o 
+randGraph : randGraph.o
+	$(CC) -o $@ randGraph.o  $(LFLAGS)
 
-addWeights : addWeights.o 
-	$(CC) $(LFLAGS) -o $@ addWeights.o
+addWeights : addWeights.o
+	$(CC) -o $@ addWeights.o $(LFLAGS)
 
-fromAdjIdx : fromAdjIdx.o 
-	$(CC) $(LFLAGS) -o $@ fromAdjIdx.o
+fromAdjIdx : fromAdjIdx.o
+	$(CC) -o $@ fromAdjIdx.o $(LFLAGS)
 
 randDoubleVector : randDoubleVector.o
-	$(CC) $(LFLAGS) -o $@ randDoubleVector.o
+	$(CC) -o $@ randDoubleVector.o $(LFLAGS)
 
 adjToEdgeArray : adjToEdgeArray.C $(COMMON)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ adjToEdgeArray.C
+	$(CC) $(CFLAGS) -o $@ adjToEdgeArray.C $(LFLAGS)
 
 adjElimSelfEdges : adjElimSelfEdges.C $(COMMON)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ adjElimSelfEdges.C
+	$(CC) $(CFLAGS) -o $@ adjElimSelfEdges.C $(LFLAGS)
 
 edgeArrayToAdj : edgeArrayToAdj.C $(COMMON)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ edgeArrayToAdj.C
+	$(CC) $(CFLAGS) -o $@ edgeArrayToAdj.C $(LFLAGS)
 
-starGraph : starGraph.o 
-	$(CC) $(LFLAGS) -o $@ starGraph.o 
+starGraph : starGraph.o
+	$(CC) -o $@ starGraph.o  $(LFLAGS)
 
-combGraph : combGraph.o 
-	$(CC) $(LFLAGS) -o $@ combGraph.o 
+combGraph : combGraph.o
+	$(CC) -o $@ combGraph.o  $(LFLAGS)
 
-expGraph : expGraph.o 
-	$(CC) $(LFLAGS) -o $@ expGraph.o 
+expGraph : expGraph.o
+	$(CC) -o $@ expGraph.o  $(LFLAGS)
 
-binTree : binTree.o 
-	$(CC) $(LFLAGS) -o $@ binTree.o 
+binTree : binTree.o
+	$(CC) -o $@ binTree.o  $(LFLAGS)
 
-reorderGraph : reorderGraph.o 
-	$(CC) $(LFLAGS) -o $@ reorderGraph.o 
+reorderGraph : reorderGraph.o
+	$(CC) -o $@ reorderGraph.o  $(LFLAGS)
 
-randomizeGraphOrder : randomizeGraphOrder.o 
-	$(CC) $(LFLAGS) -o $@ randomizeGraphOrder.o 
+randomizeGraphOrder : randomizeGraphOrder.o
+	$(CC) -o $@ randomizeGraphOrder.o  $(LFLAGS)
 
-adjGraphAddWeights : adjGraphAddWeights.o 
-	$(CC) $(LFLAGS) -o $@ adjGraphAddWeights.o
+adjGraphAddWeights : adjGraphAddWeights.o
+	$(CC) -o $@ adjGraphAddWeights.o $(LFLAGS)
 
 adjGraphAddSourceSink : adjGraphAddSourceSink.o
-	$(CC) $(LFLAGS) -o $@ adjGraphAddSourceSink.o
+	$(CC) -o $@ adjGraphAddSourceSink.o $(LFLAGS)
 
 dimacsToFlowGraph : dimacsToFlowGraph.o
-	$(CC) $(LFLAGS) -o $@ dimacsToFlowGraph.o
+	$(CC) -o $@ dimacsToFlowGraph.o $(LFLAGS)
 
 flowGraphToDimacs : flowGraphToDimacs.o
-	$(CC) $(LFLAGS) -o $@ flowGraphToDimacs.o
+	$(CC) -o $@ flowGraphToDimacs.o $(LFLAGS)
 
-adjToBinary : adjToBinary.o 
-	$(CC) $(LFLAGS) -o $@ adjToBinary.o
+adjToBinary : adjToBinary.o
+	$(CC) -o $@ adjToBinary.o $(LFLAGS)
 
-adjWghToBinary : adjWghToBinary.o 
-	$(CC) $(LFLAGS) -o $@ adjWghToBinary.o
+adjWghToBinary : adjWghToBinary.o
+	$(CC) -o $@ adjWghToBinary.o $(LFLAGS)
 
 clean :
 	rm -f *.o $(GENERATORS)
@@ -92,6 +92,6 @@ clean :
 #   	cd maxFlowGens; make clean
 #	make clean -s -C data
 
-cleansrc : 
+cleansrc :
 	make -s clean
-	rm -f $(COMMON) 
+	rm -f $(COMMON)

--- a/testData/sequenceData/Makefile
+++ b/testData/sequenceData/Makefile
@@ -9,25 +9,25 @@ GENERATORS = equalSeq randomSeq almostSortedSeq almostEqualSeq exptSeq trigramSe
 all: $(GENERATORS)
 
 classifyClean : classifyClean.C $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C 
+	$(CC) $(CFLAGS) -o $@ $@.C  $(LFLAGS)
 
 addDataSeq : addDataSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 randomSeq : randomSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 equalSeq : equalSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 almostEqualSeq : almostEqualSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 almostSortedSeq : almostSortedSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 exptSeq : exptSeq.C sequenceData.h $(SEQUENCEGEN)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $@.C
+	$(CC) $(CFLAGS) -o $@ $@.C $(LFLAGS)
 
 trigrams.o : trigrams.C $(SEQUENCEGEN) 
 	$(CC) $(CFLAGS) -c trigrams.C
@@ -36,13 +36,13 @@ trigramSeq.o : trigramSeq.C $(SEQUENCEGEN)
 	$(CC) $(CFLAGS) -c trigramSeq.C
 
 trigramSeq : trigramSeq.o trigrams.o 
-	$(CC) $(LFLAGS) -o $@ $@.o trigrams.o
+	$(CC) -o $@ $@.o trigrams.o $(LFLAGS)
 
 trigramString.o : trigramString.C $(SEQUENCEGEN)
 	$(CC) $(CFLAGS) -c trigramString.C
 
 trigramString : trigramString.o trigrams.o 
-	$(CC) $(LFLAGS) -o $@ $@.o trigrams.o
+	$(CC) -o $@ $@.o trigrams.o $(LFLAGS)
 
 clean :
 	rm -f *.o $(GENERATORS)


### PR DESCRIPTION
If used linker is ld or gold, they'll only properly accept linked objects if they are sorted in reverse topological order: if X depends on Y, X should go before Y. Thus, linked libraries should go last