### PR TITLE
Convex Hull: we must break ties for the right-most point too

### DIFF
--- a/benchmarks/convexHull/serialHull/hull.C
+++ b/benchmarks/convexHull/serialHull/hull.C
@@ -37,7 +37,8 @@ parlay::sequence<indexT> hull(parlay::sequence<point> const &S) {
   size_t l = 0;
   size_t r = 0;
   for (size_t i=1; i < n; i++) {
-    if (P[i].x > P[r].x) r = i;
+    if (P[i].x > P[r].x || ((P[i].x == P[r].x) && P[i].y > P[r].y))
+      r = i;
     if (P[i].x < P[l].x || ((P[i].x == P[l].x) && P[i].y < P[l].y))
       l = i;
   }


### PR DESCRIPTION
We must break ties on the right-most point as well to avoid reporting a colinear point. A counter example is

```
pbbs_sequencePoint2d
1,  0
1,  1
1, -1
0,  0
```

which represents the following points (number is order)

```
     1
3    0
     2
```

It should report `3, 1, 2`, but reports `3, 1, 0, 2`.